### PR TITLE
Add basic Helpers.formatarTelefone unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # sistema-gestao
 Sistema de Gestão - Obra 292
+
+## Testes
+
+Para executar o teste de unidade do helper, rode:
+
+```bash
+node tests/helpers.test.js
+```

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+// Carrega o arquivo Helpers.js
+const code = fs.readFileSync('assets/js/utils/helpers.js', 'utf8');
+
+// Ambiente mínimo para executar o script
+const sandbox = {
+  window: {},
+  document: {
+    createElement: () => ({ style: {}, href: '', download: '' }),
+    body: { appendChild: () => {}, removeChild: () => {} },
+    execCommand: () => {},
+    addEventListener: () => {}
+  },
+  navigator: {
+    clipboard: { writeText: async () => {} },
+    userAgent: '',
+    onLine: true,
+    language: 'en',
+    platform: 'test'
+  },
+  console
+};
+vm.createContext(sandbox);
+
+// Executa o script e obtém o objeto Helpers
+const script = new vm.Script(code + ';Helpers');
+const Helpers = script.runInContext(sandbox);
+
+// Teste da função formatarTelefone
+const resultado = Helpers.formatarTelefone('11987654321');
+assert.strictEqual(resultado, '(11) 98765-4321');
+
+console.log('✔ helpers.test.js passou');


### PR DESCRIPTION
## Summary
- add test folder with helpers.test.js
- document how to run the unit test in README

## Testing
- `node tests/helpers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686aa908c5348326874f3cd74b0df980