### PR TITLE
Refactor helpers to centralize notifications

### DIFF
--- a/assets/js/utils/helpers.js
+++ b/assets/js/utils/helpers.js
@@ -1,10 +1,14 @@
 /**
  * 🔧 Sistema de Utilitários (Helpers) v7.4.0 - PRODUCTION READY
- * 
+ *
  * ✅ OTIMIZADO: Debug reduzido 75% (8 → 2 logs essenciais)
  * ✅ PERFORMANCE: Operações otimizadas + cache eficiente
  * ✅ UTILITÁRIOS: Download, upload, formatação, validação
  * ✅ STORAGE: LocalStorage seguro + sanitização
+ *
+ * Este módulo comunica-se opcionalmente com `notifications.js` para exibir
+ * toasts e avisos. Caso `window.Notifications` não esteja disponível, todas as
+ * funcionalidades permanecem operacionais sem mensagens visuais.
  */
 
 const Helpers = {
@@ -25,15 +29,20 @@ const Helpers = {
         ultimaLimpeza: null
     },
 
+    // ✅ NOTIFICAÇÃO CENTRALIZADA - opcional
+    _notify(tipo, mensagem, titulo) {
+        if (typeof Notifications !== 'undefined' && typeof Notifications[tipo] === 'function') {
+            Notifications[tipo](mensagem, titulo);
+        }
+    },
+
     // === UTILITÁRIOS DE ARQUIVO ===
 
     // ✅ DOWNLOAD DE ARQUIVO - OTIMIZADO
     downloadFile(content, filename, mimeType = 'text/plain') {
         try {
             if (this.state.downloadAtivo) {
-                if (typeof Notifications !== 'undefined') {
-                    Notifications.warning('Download já em andamento');
-                }
+                this._notify('warning', 'Download já em andamento');
                 return false;
             }
 
@@ -60,19 +69,14 @@ const Helpers = {
                 this.state.downloadAtivo = false;
             }, 1000);
 
-            if (typeof Notifications !== 'undefined') {
-                Notifications.success(`Arquivo "${filename}" baixado com sucesso!`);
-            }
+            this._notify('success', `Arquivo "${filename}" baixado com sucesso!`);
 
             return true;
 
         } catch (error) {
             console.error('❌ Erro ao fazer download:', error);
             this.state.downloadAtivo = false;
-            
-            if (typeof Notifications !== 'undefined') {
-                Notifications.error('Erro ao fazer download do arquivo');
-            }
+            this._notify('error', 'Erro ao fazer download do arquivo');
             return false;
         }
     },
@@ -105,23 +109,17 @@ const Helpers = {
                         callback(content, file);
                     }
                     
-                    if (typeof Notifications !== 'undefined') {
-                        Notifications.success(`Arquivo "${file.name}" carregado com sucesso!`);
-                    }
+                    this._notify('success', `Arquivo "${file.name}" carregado com sucesso!`);
 
                 } catch (error) {
                     this.state.uploadAtivo = false;
-                    if (typeof Notifications !== 'undefined') {
-                        Notifications.error('Erro ao processar arquivo');
-                    }
+                    this._notify('error', 'Erro ao processar arquivo');
                 }
             };
 
             reader.onerror = () => {
                 this.state.uploadAtivo = false;
-                if (typeof Notifications !== 'undefined') {
-                    Notifications.error('Erro ao ler arquivo');
-                }
+                this._notify('error', 'Erro ao ler arquivo');
             };
 
             // Ler arquivo baseado no tipo
@@ -135,9 +133,7 @@ const Helpers = {
 
         } catch (error) {
             this.state.uploadAtivo = false;
-            if (typeof Notifications !== 'undefined') {
-                Notifications.error(`Erro no upload: ${error.message}`);
-            }
+            this._notify('error', `Erro no upload: ${error.message}`);
             return false;
         }
     },
@@ -525,15 +521,11 @@ const Helpers = {
                 document.body.removeChild(textArea);
             }
 
-            if (typeof Notifications !== 'undefined') {
-                Notifications.success('Texto copiado para a área de transferência!');
-            }
+            this._notify('success', 'Texto copiado para a área de transferência!');
             return true;
 
         } catch (error) {
-            if (typeof Notifications !== 'undefined') {
-                Notifications.error('Erro ao copiar texto');
-            }
+            this._notify('error', 'Erro ao copiar texto');
             return false;
         }
     },

--- a/assets/js/utils/notifications.js
+++ b/assets/js/utils/notifications.js
@@ -1,4 +1,7 @@
 (function () {
+  // Sistema de notificações simples usado por outros módulos (ex: helpers.js)
+  // para exibição de toasts e confirmações. Pode ser substituído ou removido
+  // sem quebrar funcionalidades, já que chamadas são verificadas.
   const DURATION = 4000;
 
   function getContainer() {
@@ -62,4 +65,5 @@
     mostrarToast,
     mostrarConfirmacao,
   };
+  // Outros módulos verificam a existência deste objeto antes de utilizá-lo.
 })();


### PR DESCRIPTION
## Summary
- clarify in Helpers header how notifications are used
- add internal `_notify` helper in helpers.js
- use `_notify` everywhere to avoid repeated checks
- document Notifications module and its relation to Helpers

## Testing
- `node tests/helpers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ab0474c7c8326b158c78eb9d4a4a0