### PR TITLE
Externalize Firebase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore firebase configuration file
+assets/js/config/firebaseConfig.json

--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@ Para executar o teste de unidade do helper, rode:
 ```bash
 node tests/helpers.test.js
 ```
+
+## Configuração do Firebase
+
+O sistema busca as credenciais do Firebase a partir de variáveis de ambiente
+ou de um arquivo `assets/js/config/firebaseConfig.json` (que é ignorado pelo
+Git). As variáveis de ambiente reconhecidas são:
+
+```
+FIREBASE_API_KEY
+FIREBASE_AUTH_DOMAIN
+FIREBASE_DATABASE_URL
+FIREBASE_PROJECT_ID
+FIREBASE_STORAGE_BUCKET
+FIREBASE_MESSAGING_SENDER_ID
+FIREBASE_APP_ID
+FIREBASE_MEASUREMENT_ID
+```
+
+Caso as variáveis não estejam definidas, crie o arquivo `firebaseConfig.json`
+com o mesmo formato das credenciais fornecidas pelo Firebase e coloque-o em
+`assets/js/config/`.

--- a/assets/js/config/firebase.js
+++ b/assets/js/config/firebase.js
@@ -1,19 +1,49 @@
 /* ========== 🔥 CONFIGURAÇÃO FIREBASE v7.3.0 - LIMPO ========== */
 
-// ✅ CONFIGURAÇÃO FIREBASE
-const firebaseConfig = {
-    apiKey: "AIzaSyCT0UXyU6AeurlaZdgM4_MKhzJWIdYxWg4",
-    authDomain: "sistema-gestao-obra.firebaseapp.com",
-    databaseURL: "https://sistema-gestao-obra-default-rtdb.firebaseio.com",
-    projectId: "sistema-gestao-obra",
-    storageBucket: "sistema-gestao-obra.firebasestorage.app",
-    messagingSenderId: "686804029278",
-    appId: "1:686804029278:web:758190822a19ef935e89cf",
-    measurementId: "G-RE86WX5KY2"
-};
+// ✅ CARREGAR CONFIGURAÇÃO
+function carregarConfigDeVariaveis() {
+    if (typeof process !== 'undefined' && process.env && process.env.FIREBASE_API_KEY) {
+        return {
+            apiKey: process.env.FIREBASE_API_KEY,
+            authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+            databaseURL: process.env.FIREBASE_DATABASE_URL,
+            projectId: process.env.FIREBASE_PROJECT_ID,
+            storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+            messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+            appId: process.env.FIREBASE_APP_ID,
+            measurementId: process.env.FIREBASE_MEASUREMENT_ID
+        };
+    }
+
+    if (typeof window !== 'undefined' && window.firebaseConfig) {
+        return window.firebaseConfig;
+    }
+
+    return null;
+}
+
+function carregarConfigDeArquivo() {
+    try {
+        var request = new XMLHttpRequest();
+        request.open('GET', 'assets/js/config/firebaseConfig.json', false); // sincronamente
+        request.send(null);
+        if (request.status === 200) {
+            return JSON.parse(request.responseText);
+        }
+    } catch (e) {
+        console.error('Erro ao carregar firebaseConfig.json', e);
+    }
+    return null;
+}
+
+const firebaseConfig = carregarConfigDeVariaveis() || carregarConfigDeArquivo();
 
 // ✅ INICIALIZAR FIREBASE
-firebase.initializeApp(firebaseConfig);
+if (firebaseConfig) {
+    firebase.initializeApp(firebaseConfig);
+} else {
+    console.error('Configuração do Firebase não encontrada.');
+}
 
 // ✅ CRIAR SERVIÇOS FIREBASE
 const database = firebase.database();


### PR DESCRIPTION
## Summary
- allow firebase config to be loaded from env or local json file
- add `.gitignore` entry for the json config
- document firebase env vars in README

## Testing
- `node tests/helpers.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686ab1b0d6f083268017227148887816