### PR TITLE
Add vm-based tests for main modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@ Sistema de Gestão - Obra 292
 
 ## Testes
 
-Para executar o teste de unidade do helper, rode:
+Execute a suíte completa utilizando o NPM:
+
+```bash
+npm test
+```
+
+Se preferir rodar um teste isolado basta chamar o arquivo diretamente com o
+Node.js, por exemplo:
 
 ```bash
 node tests/helpers.test.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sistema-gestao",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js"
+  }
+}

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('assets/js/modules/auth.js', 'utf8');
+
+const sandbox = {
+  window: {},
+  document: {
+    addEventListener: () => {},
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => []
+  },
+  console,
+  Validation: { isValidEmail: () => true }
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code + ';Auth');
+const Auth = script.runInContext(sandbox);
+
+let res = Auth._validarCamposLogin('user@example.com', '123456');
+assert.strictEqual(res.valido, true);
+assert.strictEqual(res.erro, '');
+assert.ok(Array.isArray(res.campos) && res.campos.length === 0);
+
+res = Auth._validarCamposLogin('bad-email', '123');
+assert.strictEqual(res.valido, false);
+assert.ok(res.erro);
+assert.ok(res.campos.includes('loginPassword'));
+
+const status = Auth.obterStatus();
+assert.strictEqual(status.autenticado, false);
+
+console.log('✔ auth.test.js passou');

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('assets/js/modules/calendar.js', 'utf8');
+
+const sandbox = {
+  window: {},
+  document: {
+    addEventListener: () => {},
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => []
+  },
+  console,
+  App: { dados: {} },
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code + ';Calendar');
+const Calendar = script.runInContext(sandbox);
+
+Calendar.gerar = () => {}; // evitar DOM
+
+Calendar.config.mesAtual = 11;
+Calendar.config.anoAtual = 2021;
+Calendar.mudarMes(1);
+assert.strictEqual(Calendar.config.mesAtual, 0);
+assert.strictEqual(Calendar.config.anoAtual, 2022);
+
+sandbox.App.dados = { foo: 'bar' };
+assert.deepStrictEqual(Calendar._verificarDependencias(), sandbox.App.dados);
+
+console.log('✔ calendar.test.js passou');

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('assets/js/modules/events.js', 'utf8');
+
+const sandbox = {
+  window: {},
+  document: { addEventListener: () => {} },
+  console,
+  App: { dados: { eventos: [] } },
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code + ';Events');
+const Events = script.runInContext(sandbox);
+
+sandbox.App.dados.eventos = [
+  { id: 1, titulo: 'Reuniao', data: '2099-01-01', tipo: 'reuniao', pessoas: ['A'] },
+  { id: 2, titulo: 'Entrega', data: '2099-01-02', tipo: 'entrega', pessoas: ['B'] }
+];
+
+let encontrados = Events.buscarEventos('Reuniao');
+assert.strictEqual(encontrados.length, 1);
+assert.strictEqual(encontrados[0].id, 1);
+
+const proximos = Events.obterProximosEventos(1);
+assert.strictEqual(proximos.length, 1);
+assert.strictEqual(proximos[0].id, 1);
+
+console.log('✔ events.test.js passou');

--- a/tests/tasks.test.js
+++ b/tests/tasks.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('assets/js/modules/tasks.js', 'utf8');
+
+const sandbox = {
+  window: {},
+  document: {
+    readyState: 'loading',
+    addEventListener: () => {},
+    getElementById: () => null
+  },
+  localStorage: { getItem: () => null, setItem: () => {} },
+  console
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code + ';Tasks');
+const Tasks = script.runInContext(sandbox);
+
+const id = Tasks._gerarId();
+assert.ok(id.startsWith('task_'));
+
+Tasks.state.tarefas.set('1', { id: '1', titulo: 'T1', dataFim: '2099-01-01', dataInicio: '2099-01-01', prioridade: 'alta', status: 'pendente', responsavel: 'A' });
+
+const lista = Tasks.obterTarefasParaCalendario('2099-01-01');
+assert.strictEqual(lista.length, 1);
+assert.strictEqual(lista[0].id, '1');
+
+console.log('✔ tasks.test.js passou');


### PR DESCRIPTION
## Summary
- create npm test script
- document how to run tests
- add unit tests for Auth, Calendar, Events and Tasks modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ab1a1e9d883269d68fc65cc095620