### PR TITLE
Fix calendar init timeout

### DIFF
--- a/assets/js/modules/calendar.js
+++ b/assets/js/modules/calendar.js
@@ -904,9 +904,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Tentar imediatamente
     if (!tentarInicializar()) {
-        // Se não conseguir, aguardar até 3 segundos
+        // Se não conseguir, aguardar até 10 segundos
         let tentativas = 0;
-        const maxTentativas = 30;
+        const maxTentativas = 100;
         
         const interval = setInterval(() => {
             tentativas++;


### PR DESCRIPTION
## Summary
- extend initialization retry window to handle slower login flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ac646f72c8326b68eadd04be38cc3