### PR TITLE
Fix auth initialization and asset paths

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -679,7 +679,7 @@
         <!-- 🔴 HEADER DA PÁGINA -->
         <div class="page-header">
             <div class="header-left">
-                <img src="img/Logo-biapo.jpg" alt="Logo BIAPO" class="logo-biapo">
+                <img src="assets/img/Logo-biapo.jpg" alt="Logo BIAPO" class="logo-biapo">
                 <div>
                     <h1 class="header-title">📅 Minha Agenda Pessoal</h1>
                     <p class="header-subtitle">Sistema de Gestão BIAPO - Obra 292</p>

--- a/assets/js/modules/auth.js
+++ b/assets/js/modules/auth.js
@@ -2,6 +2,7 @@
 
 const firebaseAuth = window.auth || (window.firebase ? window.firebase.auth() : null);
 
+
 const Auth = {
     // ✅ CONFIGURAÇÕES
     config: {
@@ -80,7 +81,11 @@ const Auth = {
                 await Persistence.salvarDadosCritico();
             }
             
-            await auth.signOut();
+            if (!firebaseAuth) {
+                Notifications.error('Serviço de autenticação indisponível');
+                return;
+            }
+            await firebaseAuth.signOut();
             this._onLogoutSucesso();
             
         } catch (error) {
@@ -104,7 +109,11 @@ const Auth = {
         try {
             this._mostrarIndicadorLogin('Criando conta...');
             
-            const userCredential = await auth.createUserWithEmailAndPassword(email, senha);
+            if (!firebaseAuth) {
+                Notifications.error('Serviço de autenticação indisponível');
+                return;
+            }
+            const userCredential = await firebaseAuth.createUserWithEmailAndPassword(email, senha);
             
             // Atualizar perfil com nome
             await userCredential.user.updateProfile({
@@ -124,7 +133,11 @@ const Auth = {
     // ✅ RECUPERAR SENHA
     async recuperarSenha(email) {
         try {
-            await auth.sendPasswordResetEmail(email);
+            if (!firebaseAuth) {
+                Notifications.error('Serviço de autenticação indisponível');
+                return;
+            }
+            await firebaseAuth.sendPasswordResetEmail(email);
             Notifications.success('Email de recuperação enviado!');
         } catch (error) {
             console.error('Erro na recuperação:', error);
@@ -580,5 +593,8 @@ const Auth = {
 document.addEventListener('DOMContentLoaded', () => {
     Auth.init();
 });
+
+// Disponibilizar objeto para handlers em inline scripts
+window.Auth = Auth;
 
 console.log('🔐 Sistema de Autenticação Firebase v6.2 carregado!');

--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
     <!-- 🔐 TELA DE LOGIN -->
     <div id="loginScreen" class="hidden">
         <div class="login-container">
-            <img src="img/Logo-biapo.jpg" alt="Logo BIAPO" class="login-logo">
+            <img src="assets/img/Logo-biapo.jpg" alt="Logo BIAPO" class="login-logo">
             <h1 class="login-title">Sistema BIAPO</h1>
             <p class="login-subtitle">Obra 292 - Museu Nacional</p>
             
@@ -422,7 +422,7 @@
         <div class="container">
             <div class="header">
                 <div class="header-left">
-                    <img src="img/Logo-biapo.jpg" alt="Logo BIAPO" class="logo-biapo">
+                    <img src="assets/img/Logo-biapo.jpg" alt="Logo BIAPO" class="logo-biapo">
                     <div>
                         <h1>Sistema de Gestão BIAPO</h1>
                         <p>Obra 292 - Museu Nacional</p>


### PR DESCRIPTION
## Summary
- expose `Auth` on `window` so inline handlers work
- guard against missing Firebase auth in logout, registration and password reset
- correct image paths for BIAPO logo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ab8017140832682a65b957e991e94