### PR TITLE
Fix Firebase init when config missing

### DIFF
--- a/assets/js/config/firebase.js
+++ b/assets/js/config/firebase.js
@@ -39,15 +39,18 @@ function carregarConfigDeArquivo() {
 const firebaseConfig = carregarConfigDeVariaveis() || carregarConfigDeArquivo();
 
 // ✅ INICIALIZAR FIREBASE
+let database = null;
+let auth = null;
+
 if (firebaseConfig) {
     firebase.initializeApp(firebaseConfig);
+    database = firebase.database();
+    auth = firebase.auth();
 } else {
     console.error('Configuração do Firebase não encontrada.');
 }
 
-// ✅ CRIAR SERVIÇOS FIREBASE
-const database = firebase.database();
-const auth = firebase.auth();
+// ✅ CRIAR SERVIÇOS FIREBASE APENAS SE INICIALIZADO
 
 // ✅ EXPOSIÇÃO CONSOLIDADA NO WINDOW (uma única vez)
 window.firebase = firebase;


### PR DESCRIPTION
## Summary
- prevent runtime errors in `firebase.js` when credentials are absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686acab3b3948326a2b8e67a67b2fe81