### PR TITLE
Add persistence module tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "sistema-gestao",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js"
+    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js"
   }
 }

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('assets/js/modules/persistence.js', 'utf8');
+
+const createStore = () => {
+  return {
+    _data: {},
+    getItem(key) { return this._data[key] || null; },
+    setItem(key, val) { this._data[key] = String(val); },
+    removeItem(key) { delete this._data[key]; }
+  };
+};
+
+const sandbox = {
+  window: {},
+  document: {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    createElement: () => ({ style: {}, appendChild: () => {}, remove: () => {} }),
+    body: { appendChild: () => {} },
+    getElementById: () => null,
+    hidden: false
+  },
+  sessionStorage: createStore(),
+  localStorage: createStore(),
+  console,
+  App: {
+    estadoSistema: { usuarioEmail: 'tester@example.com' },
+    dados: { foo: 'bar' }
+  },
+  Helpers: { storage: { set: () => {}, get: () => null } }
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code + ';Persistence');
+const Persistence = script.runInContext(sandbox);
+
+const checksum1 = Persistence._calcularChecksum({a:1});
+const checksum2 = Persistence._calcularChecksum({a:1});
+assert.strictEqual(checksum1, checksum2);
+
+const backup = {
+  dados: {foo:'bar'},
+  timestamp: new Date().toISOString(),
+  versao: '7.4',
+  usuario: 'tester@example.com',
+  checksum: Persistence._calcularChecksum({foo:'bar'})
+};
+assert.ok(Persistence._validarBackup(backup));
+
+sandbox.sessionStorage.setItem(Persistence.config.BACKUP_LOCAL_KEY, JSON.stringify(backup));
+const rec = Persistence.recuperarBackupLocal();
+assert.strictEqual(JSON.stringify(rec), JSON.stringify(backup.dados));
+
+console.log('✔ persistence.test.js passou');


### PR DESCRIPTION
## Summary
- add automated tests for `persistence.js`
- include new test in `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b001abe3c8326992ab7c469daa6ed