### PR TITLE
Fix login Enter key listener duplication

### DIFF
--- a/assets/js/modules/login-init.js
+++ b/assets/js/modules/login-init.js
@@ -298,15 +298,6 @@
         // Atualizar estatísticas a cada 30 segundos
         setInterval(atualizarEstatisticasHybrid, 30000);
         
-        // ✅ EVENTOS DE TECLADO PARA LOGIN
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-                const loginScreen = document.getElementById('loginScreen');
-                if (loginScreen && !loginScreen.classList.contains('hidden')) {
-                    Auth.fazerLogin();
-                }
-            }
-        });
         
         // ✅ MOSTRAR/OCULTAR SEÇÕES DE DEBUG BASEADO NO USUÁRIO
         function toggleDebugSections() {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "sistema-gestao",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js"
+    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js"
   }
 }

--- a/tests/login-keydown.test.js
+++ b/tests/login-keydown.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const authCode = fs.readFileSync('assets/js/modules/auth.js', 'utf8');
+const loginInitCode = fs.readFileSync('assets/js/modules/login-init.js', 'utf8');
+
+const events = {};
+const sandbox = {
+  window: {},
+  document: {
+    addEventListener: (type, cb) => { events[type] = cb; },
+    getElementById: (id) => {
+      if (id === 'loginScreen') {
+        return { classList: { contains: () => false } };
+      }
+      return { classList: { contains: () => false } };
+    },
+    querySelector: () => null,
+    querySelectorAll: () => []
+  },
+  console,
+  Notifications: { warning: () => {}, error: () => {}, info: () => {} },
+  Persistence: { state: {} },
+  App: {},
+  PersonalAgenda: {},
+  DataStructure: {},
+  HybridSync: {},
+  HybridSync_Debug: {},
+  setTimeout: setTimeout,
+  setInterval: setInterval,
+  alert: () => {}
+};
+vm.createContext(sandbox);
+
+const authScript = new vm.Script(authCode + ';Auth');
+const Auth = authScript.runInContext(sandbox);
+
+let callCount = 0;
+Auth.fazerLogin = () => { callCount++; };
+
+Auth._configurarEventosTeclado();
+const handlerBefore = events['keydown'];
+
+// Executar login-init.js e verificar que nao adiciona outro listener
+const loginScript = new vm.Script(loginInitCode);
+loginScript.runInContext(sandbox);
+const handlerAfter = events['keydown'];
+assert.strictEqual(handlerAfter, handlerBefore, 'login-init nao deve registrar outro keydown');
+
+// Simular pressionar Enter
+handlerAfter({ key: 'Enter' });
+assert.strictEqual(callCount, 1);
+
+console.log('✔ login-keydown.test.js passou');
+


### PR DESCRIPTION
## Summary
- remove duplicate keydown listener from `login-init.js`
- add regression test ensuring login key handler is only defined in `auth.js`
- include new test in npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b01f0faac8326a4139e1300d8c808