### PR TITLE
Add login/logout event hooks

### DIFF
--- a/assets/js/modules/auth.js
+++ b/assets/js/modules/auth.js
@@ -18,7 +18,9 @@ const Auth = {
         tentativasLogin: 0,
         loginEmAndamento: false,
         autoLoginTentado: false,
-        listeners: new Set()
+        listeners: new Set(),
+        loginCallbacks: new Set(),
+        logoutCallbacks: new Set()
     },
 
     // ✅ FAZER LOGIN
@@ -173,6 +175,9 @@ const Auth = {
         // Redirecionar após delay
         setTimeout(() => {
             this._mostrarSistema();
+            this.state.loginCallbacks.forEach(cb => {
+                try { cb(user); } catch (e) { console.error(e); }
+            });
         }, this.config.AUTO_REDIRECT_DELAY);
     },
 
@@ -226,7 +231,11 @@ const Auth = {
         
         this._limparSessaoLocal();
         this._mostrarTelaLogin();
-        
+
+        this.state.logoutCallbacks.forEach(cb => {
+            try { cb(); } catch (e) { console.error(e); }
+        });
+
         Notifications.info('Logout realizado com sucesso');
     },
 
@@ -546,6 +555,18 @@ const Auth = {
         return !!this.state.usuarioAtual;
     },
 
+    onLogin(callback) {
+        if (typeof callback === 'function') {
+            this.state.loginCallbacks.add(callback);
+        }
+    },
+
+    onLogout(callback) {
+        if (typeof callback === 'function') {
+            this.state.logoutCallbacks.add(callback);
+        }
+    },
+
     // ✅ INICIALIZAÇÃO DO MÓDULO
     init() {
         console.log('🔐 Inicializando sistema de autenticação...');
@@ -586,6 +607,8 @@ const Auth = {
             }
         });
         this.state.listeners.clear();
+        this.state.loginCallbacks.clear();
+        this.state.logoutCallbacks.clear();
     }
 };
 

--- a/assets/js/modules/login-init.js
+++ b/assets/js/modules/login-init.js
@@ -268,31 +268,16 @@
             }, 1000);
         });
         
-        // ✅ INTERCEPTAR LOGIN SUCESSO PARA MOSTRAR SISTEMA
-        if (typeof Auth !== 'undefined') {
-            // Sobrescrever função de sucesso do Auth para integrar com nossa interface
-            const originalOnLoginSucesso = Auth._onLoginSucesso;
-            Auth._onLoginSucesso = function(user) {
-                // Chamar função original
-                originalOnLoginSucesso.call(this, user);
-                
-                // Mostrar sistema principal
+        // ✅ REGISTRAR LISTENERS DE LOGIN/LOGOUT
+        if (typeof Auth !== 'undefined' && typeof Auth.onLogin === 'function') {
+            Auth.onLogin(() => {
                 mostrarSistemaPrincipal();
-                
                 console.log('✅ Login realizado - sistema principal exibido');
-            };
-            
-            // Sobrescrever logout para mostrar tela de login
-            const originalOnLogoutSucesso = Auth._onLogoutSucesso;
-            Auth._onLogoutSucesso = function() {
-                // Chamar função original
-                originalOnLogoutSucesso.call(this);
-                
-                // Mostrar tela de login
+            });
+            Auth.onLogout(() => {
                 mostrarTelaLogin();
-                
                 console.log('✅ Logout realizado - tela de login exibida');
-            };
+            });
         }
         
         // Atualizar estatísticas a cada 30 segundos


### PR DESCRIPTION
## Summary
- expose `onLogin` and `onLogout` callbacks in `auth.js`
- clear those callbacks on destroy
- hook login-init UI updates to new callbacks
- remove `_onLoginSucesso`/`_onLogoutSucesso` overrides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b041292888326bf410acd0e724ba5