### PR TITLE
Fix Notifications fallback and add integration tests

### DIFF
--- a/assets/js/utils/validation.js
+++ b/assets/js/utils/validation.js
@@ -363,7 +363,9 @@ function executarCorrecaoCompleta() {
     
     // 1. Implementar sistemas
     implementarValidationCompleto();
-    implementarNotificationsCompleto();
+    if (!window.Notifications) {
+        implementarNotificationsCompleto();
+    }
     
     // 2. Verificar funcionamento
     const resultados = verificarSistemas();
@@ -378,10 +380,12 @@ function executarCorrecaoCompleta() {
     if (sucesso) {
         console.log('🎉 CORREÇÃO COMPLETA SUCESSO!');
         
-        // Testar com notificação real
-        setTimeout(() => {
-            window.Notifications.success('Sistema de emergência ativado com sucesso!', 'Correção Aplicada');
-        }, 500);
+        // Testar com notificação real se disponível
+        if (window.Notifications && typeof window.Notifications.success === 'function') {
+            setTimeout(() => {
+                window.Notifications.success('Sistema de emergência ativado com sucesso!', 'Correção Aplicada');
+            }, 500);
+        }
         
         return true;
     } else {
@@ -402,7 +406,7 @@ function monitorarSistemasEmergencia() {
             implementarValidationCompleto();
         }
         
-        if (!status.notifications) {
+        if (!status.notifications && !window.Notifications) {
             console.warn('⚠️ Notifications perdido, restaurando...');
             implementarNotificationsCompleto();
         }
@@ -476,7 +480,7 @@ function testarIntegracaoAuth() {
         console.log('🧪 Para testar Auth: CorrecaoEmergencia.testarAuth()');
         
         // Notificar usuário se tudo ok
-        if (authOk) {
+        if (authOk && window.Notifications && typeof window.Notifications.success === 'function') {
             setTimeout(() => {
                 window.Notifications.success('Todos os sistemas funcionando!', 'Correção Completa');
             }, 1000);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "sistema-gestao",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js"
+    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js && node tests/notifications-dependency.test.js"
   }
 }

--- a/tests/login-keydown.test.js
+++ b/tests/login-keydown.test.js
@@ -53,4 +53,5 @@ handlerAfter({ key: 'Enter' });
 assert.strictEqual(callCount, 1);
 
 console.log('✔ login-keydown.test.js passou');
+process.exit(0);
 

--- a/tests/notifications-dependency.test.js
+++ b/tests/notifications-dependency.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const notifCode = fs.readFileSync('assets/js/utils/notifications.js', 'utf8');
+const tasksCode = fs.readFileSync('assets/js/modules/tasks.js', 'utf8');
+
+const sandbox = {
+  window: {},
+  document: {
+    readyState: 'loading',
+    addEventListener: () => {},
+    getElementById: () => ({
+      addEventListener: () => {},
+      appendChild: () => {},
+      innerHTML: '',
+      style: {},
+    }),
+    querySelector: () => null,
+    createElement: () => ({
+      className: '',
+      style: {},
+      addEventListener: () => {},
+      remove: () => {},
+      appendChild: () => {},
+    }),
+    body: { appendChild: () => {} },
+  },
+  requestAnimationFrame: (cb) => cb(),
+  setTimeout: setTimeout,
+  setInterval: () => {},
+  localStorage: { getItem: () => null, setItem: () => {} },
+  console,
+};
+vm.createContext(sandbox);
+
+// Carrega Notifications e cria o objeto global
+vm.runInContext(notifCode, sandbox);
+assert.ok(sandbox.window.Notifications, 'Notifications nao definido');
+
+const script = new vm.Script(tasksCode + ';Tasks');
+const Tasks = script.runInContext(sandbox);
+
+const id = Tasks._gerarId();
+assert.ok(id.startsWith('task_'));
+
+console.log('✔ notifications-dependency.test.js passou');
+process.exit(0);
+


### PR DESCRIPTION
## Summary
- prevent emergency `validation.js` from overwriting an existing Notifications object
- guard notification calls behind availability checks
- update monitoring routine to only recreate Notifications if missing
- ensure login-keydown test exits cleanly
- add new integration test verifying modules work with `notifications.js`
- run new test through npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b04147eec832697c1473376c97a45