### PR TITLE
Fix toast injection via textContent

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -767,6 +767,9 @@ body {
     transition: transform 0.3s ease;
     min-width: 250px;
 }
+.toast strong {
+    margin-right: 4px;
+}
 
 .toast.show {
     transform: translateX(0);

--- a/assets/js/utils/notifications.js
+++ b/assets/js/utils/notifications.js
@@ -17,7 +17,17 @@
   function createToast(message, type, title) {
     const toast = document.createElement('div');
     toast.className = `toast ${type}`;
-    toast.innerHTML = title ? `<strong>${title}</strong> ${message}` : message;
+
+    if (title) {
+      const strong = document.createElement('strong');
+      strong.textContent = title;
+      toast.appendChild(strong);
+      toast.appendChild(document.createTextNode(' '));
+    }
+
+    const text = document.createTextNode(message);
+    toast.appendChild(text);
+
     toast.addEventListener('click', () => toast.remove());
     return toast;
   }

--- a/modules/chat-styles.css
+++ b/modules/chat-styles.css
@@ -475,6 +475,9 @@
     min-width: 200px;
     animation: toast-in 0.3s ease;
 }
+.toast strong {
+    margin-right: 4px;
+}
 
 @keyframes toast-in {
     from { transform: translateX(100%); opacity: 0; }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "sistema-gestao",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js"
+    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js && node tests/notifications.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "^26.1.0"
   }
 }

--- a/tests/login-keydown.test.js
+++ b/tests/login-keydown.test.js
@@ -28,7 +28,7 @@ const sandbox = {
   HybridSync: {},
   HybridSync_Debug: {},
   setTimeout: setTimeout,
-  setInterval: setInterval,
+  setInterval: () => ({ unref: () => {} }),
   alert: () => {}
 };
 vm.createContext(sandbox);

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+const code = fs.readFileSync('assets/js/utils/notifications.js', 'utf8');
+
+const dom = new JSDOM('<!DOCTYPE html><body></body>', { runScripts: 'outside-only' });
+const { window } = dom;
+window.requestAnimationFrame = (cb) => cb();
+
+const sandbox = {
+  window,
+  document: window.document,
+  console,
+  requestAnimationFrame: window.requestAnimationFrame,
+  setTimeout: window.setTimeout,
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code);
+script.runInContext(sandbox);
+
+window.wasExecuted = false;
+window.Notifications.success('<script>window.wasExecuted = true;</script>', 'Alerta');
+
+const toast = window.document.querySelector('.toast');
+assert.ok(toast);
+assert.strictEqual(toast.querySelector('script'), null);
+assert.strictEqual(window.wasExecuted, false);
+assert.ok(toast.textContent.includes('<script>'));
+
+console.log('✔ notifications.test.js passou');


### PR DESCRIPTION
## Summary
- safely render toast title and message using `textContent`
- give `<strong>` elements spacing in toast styles
- run toast tests with jsdom and stub timers
- prevent login keydown test from hanging
- update test suite to include notifications test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0418a81c8326954e39c7a65e13ca