### PR TITLE
Improve missing Firebase config handling

### DIFF
--- a/assets/js/config/firebase.js
+++ b/assets/js/config/firebase.js
@@ -78,7 +78,9 @@ window.firebaseInitPromise = firebaseConfigPromise
     .finally(() => {
         window.firebase = firebase;
         window.database = database;
-        window.auth = auth;
+        if (auth) {
+            window.auth = auth;
+        }
         console.log('🔥 Firebase v7.3.0 LIMPO - exposições consolidadas');
     });
 

--- a/assets/js/modules/auth.js
+++ b/assets/js/modules/auth.js
@@ -551,7 +551,12 @@ const Auth = {
         console.log('🔐 Inicializando sistema de autenticação...');
 
         if (!firebaseAuth) {
-            Notifications.error('Serviço de autenticação indisponível');
+            const msg = 'Firebase não configurado. Consulte o README.md (seção "Configuração do Firebase")';
+            if (typeof Notifications !== 'undefined') {
+                Notifications.error(msg);
+            } else {
+                console.error(msg);
+            }
             return;
         }
 
@@ -591,11 +596,22 @@ const Auth = {
 
 // ✅ INICIALIZAÇÃO AUTOMÁTICA
 document.addEventListener('DOMContentLoaded', async () => {
+    let cfg = null;
     if (window.firebaseInitPromise) {
-        await window.firebaseInitPromise;
+        cfg = await window.firebaseInitPromise;
     }
-    firebaseAuth = window.auth || (window.firebase ? window.firebase.auth() : null);
-    Auth.init();
+
+    if (cfg) {
+        firebaseAuth = window.auth || (window.firebase ? window.firebase.auth() : null);
+        Auth.init();
+    } else {
+        const msg = 'Firebase não configurado. Consulte o README.md (seção "Configuração do Firebase")';
+        if (typeof Notifications !== 'undefined') {
+            Notifications.error(msg);
+        } else {
+            console.error(msg);
+        }
+    }
 });
 
 // Disponibilizar objeto para handlers em inline scripts

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "sistema-gestao",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js"
+    "test": "node tests/helpers.test.js && node tests/auth.test.js && node tests/auth-missing-config.test.js && node tests/calendar.test.js && node tests/events.test.js && node tests/tasks.test.js && node tests/persistence.test.js && node tests/login-keydown.test.js"
   }
 }

--- a/tests/auth-missing-config.test.js
+++ b/tests/auth-missing-config.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync('assets/js/modules/auth.js', 'utf8');
+
+const messages = [];
+const sandbox = {
+  window: {},
+  document: {
+    addEventListener: () => {},
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => []
+  },
+  console,
+  Notifications: { error: (msg) => messages.push(msg), warning: () => {}, info: () => {} },
+  Persistence: { state: {} },
+  App: {},
+  Helpers: { storage: { set: () => {}, get: () => null } },
+  setTimeout,
+  setInterval
+};
+vm.createContext(sandbox);
+
+const script = new vm.Script(code + ';Auth');
+const Auth = script.runInContext(sandbox);
+
+Auth.init();
+
+assert.ok(messages.some(m => m.includes('Firebase não configurado')));
+
+console.log('✔ auth-missing-config.test.js passou');


### PR DESCRIPTION
## Summary
- expose `auth` only if initialized
- warn about missing Firebase setup in auth module
- skip auth initialization when config is absent
- add regression test for missing Firebase configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b041c13808326ad7501b9ecf62663