### PR TITLE
Convert JS modules to ES modules

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -20,9 +20,9 @@
     <script src="assets/js/utils/validation.js"></script>
     <script src="assets/js/utils/notifications.js"></script>
     <script src="assets/js/core/data.js"></script>
-    <script src="assets/js/core/app.js"></script>
-    <script src="assets/js/modules/persistence.js"></script>
-    <script src="assets/js/modules/auth.js"></script>
+    <script src="assets/js/core/app.js" type="module"></script>
+    <script src="assets/js/modules/persistence.js" type="module"></script>
+    <script src="assets/js/modules/auth.js" type="module"></script>
 <script src="assets/js/utils/corretor_sync_participantes_v8.12.js"></script>
 <script src="assets/js/utils/inicializador_sistema.js"></script>
 

--- a/assets/js/core/app.js
+++ b/assets/js/core/app.js
@@ -839,7 +839,9 @@ const App = {
 };
 
 // ✅ EXPOSIÇÃO GLOBAL
-window.App = App;
+if (typeof window !== 'undefined') {
+    window.App = App;
+}
 
 // ✅ INICIALIZAÇÃO AUTOMÁTICA
 document.addEventListener('DOMContentLoaded', () => {
@@ -863,6 +865,8 @@ if (document.readyState === 'complete' || document.readyState === 'interactive')
 
 console.log('📱 App.js v8.12.1 CORRIGIDO carregado!');
 console.log('🔥 Correções: novaTarefa → tarefa | Firebase offline | Salvamento otimizado');
+
+export default App;
 
 /*
 🔥 APP.JS v8.12.1 CORRIGIDO - CHANGELOG:

--- a/assets/js/modules/admin-users-manager.js
+++ b/assets/js/modules/admin-users-manager.js
@@ -10,6 +10,8 @@
  * - 🔧 CORRIGIDO: Erro de sintaxe linha 34
  */
 
+import Auth from './auth.js';
+
 const AdminUsersManager = {
     // ✅ CONFIGURAÇÃO v8.5
     config: {
@@ -1109,7 +1111,9 @@ const AdminUsersManager = {
 };
 
 // ✅ EXPOSIÇÃO GLOBAL
-window.AdminUsersManager = AdminUsersManager;
+if (typeof window !== 'undefined') {
+    window.AdminUsersManager = AdminUsersManager;
+}
 
 // ✅ AUTO-INICIALIZAÇÃO
 function inicializarAdminUsersManagerV85() {
@@ -1153,3 +1157,5 @@ console.log('👥 AdminUsersManager v8.5 CORRIGIDO - ERRO DE SINTAXE RESOLVIDO!'
 console.log('🏢 5 Departamentos reais + Interface administrativa funcionando');
 console.log('🔧 Linha 34 corrigida - JavaScript válido');
 console.log('✅ Pronto para integração com Auth.js v8.4.2');
+
+export default AdminUsersManager;

--- a/assets/js/modules/auth.js
+++ b/assets/js/modules/auth.js
@@ -1,5 +1,8 @@
 /* ========== 🔐 AUTH BIAPO v8.4.2 OTIMIZADO - DEPARTAMENTOS REAIS CORRIGIDOS ========== */
 
+import Calendar from './calendar.js';
+import App from '../core/app.js';
+
 var Auth = {
     // ✅ CONFIGURAÇÃO OTIMIZADA
     config: {
@@ -987,7 +990,9 @@ var Auth = {
 
 // ========== EXPOSIÇÃO GLOBAL ==========
 
-window.Auth = Auth;
+if (typeof window !== 'undefined') {
+    window.Auth = Auth;
+}
 
 // ========== COMANDOS ÚTEIS OTIMIZADOS v8.4.2 ==========
 
@@ -1117,6 +1122,8 @@ window.addEventListener('beforeunload', function() {
 
 console.log('🔐 Auth BIAPO v8.4.2 CORRIGIDA - DEPARTAMENTOS REAIS IMPLEMENTADOS!');
 console.log('⚡ Correções: Departamentos reais + Fallback corrigido + Cache otimizado');
+
+export default Auth;
 
 /*
 ========== ✅ AUTH BIAPO v8.4.2 CORRIGIDA - DEPARTAMENTOS REAIS IMPLEMENTADOS ==========

--- a/assets/js/modules/calendar.js
+++ b/assets/js/modules/calendar.js
@@ -11,6 +11,8 @@
  * - ✅ TESTADO: Compatibilidade total com App.js v8.12.0
  */
 
+import App from '../core/app.js';
+
 const Calendar = {
     // ✅ CONFIGURAÇÕES CORRIGIDAS v8.12.2
     config: {
@@ -1409,7 +1411,9 @@ ${tipoItem.toUpperCase()}: ${titulo}${item.descricao ? ' - ' + item.descricao : 
 };
 
 // ✅ EXPOSIÇÃO GLOBAL
-window.Calendar = Calendar;
+if (typeof window !== 'undefined') {
+    window.Calendar = Calendar;
+}
 
 // Funções globais atualizadas
 window.abrirResumoDia = (data) => Calendar.abrirResumoDia(data);
@@ -1421,6 +1425,8 @@ console.log('📅 Calendar.js v8.12.2 COMPLETO E CORRIGIDO carregado!');
 console.log('🔥 Correções: Erro regex resolvido + Funções essenciais implementadas');
 console.log('✅ Compatibilidade: App.js v8.12.0 + Events.js v8.12.1');
 console.log('🎯 Resultado: Calendário funcionando completamente');
+
+export default Calendar;
 
 /*
 🔥 CALENDAR.JS v8.12.2 COMPLETO E CORRIGIDO - CHANGELOG:

--- a/assets/js/modules/events.js
+++ b/assets/js/modules/events.js
@@ -9,6 +9,10 @@
  * - ✅ Modal de edição completo funcionando
  */
 
+import App from '../core/app.js';
+import Auth from './auth.js';
+import Persistence from './persistence.js';
+
 const Events = {
     // ✅ CONFIGURAÇÕES ATUALIZADAS v8.12.1
     config: {
@@ -1149,7 +1153,9 @@ Para ${acao}, você precisa estar logado no sistema.
 };
 
 // ✅ EXPOSIÇÃO GLOBAL
-window.Events = Events;
+if (typeof window !== 'undefined') {
+    window.Events = Events;
+}
 
 // Funções globais atualizadas
 window.abrirEdicaoEvento = (id) => Events.abrirModalEdicao(id);
@@ -1161,6 +1167,8 @@ console.log('📅 Events.js v8.12.1 CORRIGIDO carregado!');
 console.log('🔥 Correção: this._obterParticipantesBiapo() → _obterParticipantesBiapoLocal()');
 console.log('✅ Verificações de segurança Auth.js e App.js adicionadas');
 console.log('✅ Todas as funcionalidades v8.12.0 mantidas');
+
+export default Events;
 
 /*
 🔥 EVENTS.JS v8.12.1 CORRIGIDO - PROBLEMA RESOLVIDO:

--- a/assets/js/modules/persistence.js
+++ b/assets/js/modules/persistence.js
@@ -9,6 +9,9 @@
  * - ✅ Retry otimizado com backoff linear
  */
 
+import App from '../core/app.js';
+import Auth from './auth.js';
+
 const Persistence = {
     // ✅ CONFIGURAÇÕES OTIMIZADAS
     config: {
@@ -704,7 +707,9 @@ window.salvarDadosCritico = () => Persistence.salvarDadosCritico();
 window.salvarDadosImediato = () => Persistence.salvarDadosCritico();
 
 // ✅ EXPOSIÇÃO GLOBAL
-window.Persistence = Persistence;
+if (typeof window !== 'undefined') {
+    window.Persistence = Persistence;
+}
 
 // 🔥 DEBUG OTIMIZADO v8.2.1
 window.Persistence_Debug = {
@@ -750,6 +755,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 console.log('💾 Persistence.js v8.2.1 OTIMIZADA - LIMPEZA CONSERVADORA MODERADA aplicada!');
 console.log('⚡ Otimizações: Cache modo anônimo + Validação simplificada + Backup otimizado + Timeouts reduzidos');
+
+export default Persistence;
 
 /*
 🔥 OTIMIZAÇÕES APLICADAS v8.2.1:

--- a/index.html
+++ b/index.html
@@ -25,12 +25,12 @@
 <script src="assets/js/utils/validation.js"></script>
 <script src="assets/js/utils/notifications.js"></script>
 <script src="assets/js/core/data.js"></script>
-<script src="assets/js/core/app.js"></script>
-<script src="assets/js/modules/persistence.js"></script>
-<script src="assets/js/modules/auth.js"></script>
-<script src="assets/js/modules/events.js"></script>
-<script src="assets/js/modules/calendar.js"></script>
-<script src="assets/js/modules/admin-users-manager.js"></script>
+<script src="assets/js/core/app.js" type="module"></script>
+<script src="assets/js/modules/persistence.js" type="module"></script>
+<script src="assets/js/modules/auth.js" type="module"></script>
+<script src="assets/js/modules/events.js" type="module"></script>
+<script src="assets/js/modules/calendar.js" type="module"></script>
+<script src="assets/js/modules/admin-users-manager.js" type="module"></script>
 <script src="assets/js/utils/sistema_sincronizado_v8110.js"></script>
 <script src="assets/js/utils/corretor_sync_participantes_v8.12.js"></script>
 <script src="assets/js/utils/inicializador_sistema.js"></script>


### PR DESCRIPTION
## Summary
- convert core and module JS files to use ES module syntax
- update HTML pages to load modules with `type="module"`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e8c10709c83268cae5366189f81cc