### PR TITLE
Add Vite bundler setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore firebase configuration file
 assets/js/config/firebaseConfig.json
+node_modules/
+dist/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,9 +4,22 @@ Sistema de Gestão - Obra 292
 ## Como executar
 
 Com a modularização, todo o código está concentrado no arquivo
-`index.html` e nos scripts dentro de `assets/`. Rode o sistema servindo
-o diretório via um servidor estático. Com o Node.js instalado é possível
-utilizar o `http-server`:
+`index.html` e nos scripts dentro de `assets/`. Agora o projeto utiliza o
+[Vite](https://vitejs.dev/) para servir e gerar a versão final. Para
+iniciar o modo de desenvolvimento execute:
+
+```bash
+npm run dev
+```
+
+Para produzir os arquivos otimizados em `dist/` utilize:
+
+```bash
+npm run build
+```
+
+Se preferir um servidor estático simples, ainda é possível usar o
+`http-server`:
 
 ```bash
 npx http-server -p 8080

--- a/agenda.html
+++ b/agenda.html
@@ -10,21 +10,21 @@
     <link rel="stylesheet" href="assets/css/calendar.css">
     
     <!-- ✅ FIREBASE SCRIPTS -->
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-database-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js" vite-ignore></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-database-compat.js" vite-ignore></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js" vite-ignore></script>
     
     <!-- 🔥 SISTEMA UNIFICADO COMPLETO v8.11.0 -->
-    <script src="assets/js/config/firebase.js"></script>
-    <script src="assets/js/utils/helpers.js"></script>
-    <script src="assets/js/utils/validation.js"></script>
-    <script src="assets/js/utils/notifications.js"></script>
-    <script src="assets/js/core/data.js"></script>
-    <script src="assets/js/core/app.js" type="module"></script>
-    <script src="assets/js/modules/persistence.js" type="module"></script>
-    <script src="assets/js/modules/auth.js" type="module"></script>
-<script src="assets/js/utils/corretor_sync_participantes_v8.12.js"></script>
-<script src="assets/js/utils/inicializador_sistema.js"></script>
+    <script src="assets/js/config/firebase.js" vite-ignore></script>
+    <script src="assets/js/utils/helpers.js" vite-ignore></script>
+    <script src="assets/js/utils/validation.js" vite-ignore></script>
+    <script src="assets/js/utils/notifications.js" vite-ignore></script>
+    <script src="assets/js/core/data.js" vite-ignore></script>
+    <script src="assets/js/core/app.js" type="module" vite-ignore></script>
+    <script src="assets/js/modules/persistence.js" type="module" vite-ignore></script>
+    <script src="assets/js/modules/auth.js" type="module" vite-ignore></script>
+<script src="assets/js/utils/corretor_sync_participantes_v8.12.js" vite-ignore></script>
+<script src="assets/js/utils/inicializador_sistema.js" vite-ignore></script>
 
     <style>
         /* 🔴 CORES BIAPO */
@@ -2763,6 +2763,6 @@
         }
 
         </script>
-        <script src="src/main.js"></script>
+        <script type="module" src="/src/main.js"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,30 +10,30 @@
 <link rel="stylesheet" href="assets/css/calendar.css">
   
     <!-- ✅ BIBLIOTECAS EXTERNAS -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" vite-ignore></script>
     
     <!-- ✅ FIREBASE SCRIPTS -->
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-database-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js" vite-ignore></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-database-compat.js" vite-ignore></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js" vite-ignore></script>
     
 
     
 <!-- 🔥 SISTEMA CORE UNIFICADO v8.11.0 - SEM ARQUIVOS 404 -->
-<script src="assets/js/config/firebase.js"></script>
-<script src="assets/js/utils/helpers.js"></script>
-<script src="assets/js/utils/validation.js"></script>
-<script src="assets/js/utils/notifications.js"></script>
-<script src="assets/js/core/data.js"></script>
-<script src="assets/js/core/app.js" type="module"></script>
-<script src="assets/js/modules/persistence.js" type="module"></script>
-<script src="assets/js/modules/auth.js" type="module"></script>
-<script src="assets/js/modules/events.js" type="module"></script>
-<script src="assets/js/modules/calendar.js" type="module"></script>
-<script src="assets/js/modules/admin-users-manager.js" type="module"></script>
-<script src="assets/js/utils/sistema_sincronizado_v8110.js"></script>
-<script src="assets/js/utils/corretor_sync_participantes_v8.12.js"></script>
-<script src="assets/js/utils/inicializador_sistema.js"></script>
+<script src="assets/js/config/firebase.js" vite-ignore></script>
+<script src="assets/js/utils/helpers.js" vite-ignore></script>
+<script src="assets/js/utils/validation.js" vite-ignore></script>
+<script src="assets/js/utils/notifications.js" vite-ignore></script>
+<script src="assets/js/core/data.js" vite-ignore></script>
+<script src="assets/js/core/app.js" type="module" vite-ignore></script>
+<script src="assets/js/modules/persistence.js" type="module" vite-ignore></script>
+<script src="assets/js/modules/auth.js" type="module" vite-ignore></script>
+<script src="assets/js/modules/events.js" type="module" vite-ignore></script>
+<script src="assets/js/modules/calendar.js" type="module" vite-ignore></script>
+<script src="assets/js/modules/admin-users-manager.js" type="module" vite-ignore></script>
+<script src="assets/js/utils/sistema_sincronizado_v8110.js" vite-ignore></script>
+<script src="assets/js/utils/corretor_sync_participantes_v8.12.js" vite-ignore></script>
+<script src="assets/js/utils/inicializador_sistema.js" vite-ignore></script>
 
     <style>
         /* 🔴 CORES BIAPO */
@@ -521,6 +521,6 @@
 
 
     
-    <script src="src/main.js"></script>
+    <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "sistema-gestao",
   "version": "1.0.0",
   "scripts": {
-    
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "vite": "^7.0.3"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    assetsDir: 'assets',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        agenda: resolve(__dirname, 'agenda.html')
+      },
+      output: {
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name][extname]'
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- set up Vite with dev and build scripts
- configure output to `dist/`
- update HTML files to work with Vite
- document usage of new scripts
- ignore build artifacts and dependencies

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ea2df0d188326b61852684a599a45